### PR TITLE
Changed profile_messages.csv to add missing field from Garmin Fenix 5s

### DIFF
--- a/config/profile_messages.csv
+++ b/config/profile_messages.csv
@@ -308,6 +308,7 @@ activity,,,,,,,,,,,,,,,
 ,4,event_type,event_type,,,,,,,,,,,,1
 ,5,local_timestamp,local_date_time,,,,,,,,,,"timestamp epoch expressed in local time, used to convert activity timestamps to local time ",,1
 ,6,event_group,uint8,,,,,,,,,,,,1
+,7,undocumented_field_7,uint8,,,,,,,,,,,,1
 ,,,,,,,,,,,,,,,
 session,,,,,,,,,,,,,,,
 ,254,message_index,message_index,,,,,,,,,,Selected bit is set for the current session.,,1


### PR DESCRIPTION
Hi!
Thank you for building such an awesome library that is correctly encoding the data.
I was playing around with my devices (Fenix 3, Vivosmart 3 and Fenix 5s) and found out that 5s could not parse the data because the definition was missing. I got the definition from here https://github.com/scrapper/fit4ruby/blob/master/lib/fit4ruby/GlobalFitMessages.rb#L779 :) 